### PR TITLE
refactor: use type instead of interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "od",
-    "version": "3.0.10",
+    "version": "3.0.11",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "od",
-    "version": "3.0.10",
+    "version": "3.0.11",
     "description": "Oh dear, another date library",
     "main": "lib/index.cjs.js",
     "types": "lib/index.cjs.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { subtract } from './subtract'
 import { startOf } from './start-of'
 import { distance } from './distance'
 
-interface D {
+type D = {
     of: typeof of;
     add: typeof add;
     subtract: typeof subtract;

--- a/test/test-index.ts
+++ b/test/test-index.ts
@@ -6,12 +6,9 @@ import test from 'ava'
 
 import D from '../src/index'
 
-
 const start = new Date(Date.UTC(2000, 0, 1, 0, 0, 0, 0))
 
-
 test('should support currying `add`', t => {
-
     const addMonth = D.add('month')
     t.deepEqual(
         new Date(Date.UTC(2000, 1, 1, 0, 0, 0, 0)),
@@ -20,7 +17,6 @@ test('should support currying `add`', t => {
 })
 
 test('should support currying `subtract`', t => {
-
     const subtractMonth = D.subtract('month')
     t.deepEqual(
         new Date(Date.UTC(1999, 11, 1, 0, 0, 0, 0)),
@@ -29,7 +25,6 @@ test('should support currying `subtract`', t => {
 })
 
 test('should support currying `get`', t => {
-
     const getYear = D.get('year')
     t.deepEqual(
         2000,


### PR DESCRIPTION
This exposes the properties of the top-level default export from index.js in the type hints, rather than an opaque interface mysteriously named `D`