### PR TITLE
chore(renovate): group size-limit packages together

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,13 @@
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
+    },
+    {
+      "matchPackagePatterns": [
+        "^@size-limit/",
+        "^size-limit$"
+      ],
+      "groupName": ["size-limit packages"]
     }
   ],
   "timezone": "America/Chicago",


### PR DESCRIPTION
Because @size-limit/preset-small-lib uses an exact peerDependency
on size-limit, so npm 7's peer resolution strategy fails when
both are updated in separate pull requests.