### PR TITLE
chore: remove prepublish npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "types": "lib/src/index.js",
   "sideEffects": false,
   "scripts": {
-    "prepublishOnly": "npm run clean && npm run build",
     "benchmark": "ts-node perf/add.ts",
     "build": "tsc --build .",
     "clean": "rimraf --no-glob -- lib",


### PR DESCRIPTION
Now that we only publish with semantic-release, this is
inherently part of our workflow and we don't need this hook.