### PR TITLE
refactor!: flatten the dir structure of published files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ flycheck_*
 /scratch
 /typedoc
 /.npmrc
+/*.js
+/*.js.map
+/*.d.ts
+/*.d.ts.map

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# [6.0.0](https://github.com/strong-roots-capital/od/compare/v5.0.0...v6.0.0) (2022-01-23)
+
+
+* feat!: target ES6 JavaScript ([a8f703d](https://github.com/strong-roots-capital/od/commit/a8f703d83cff13e15a44c8392e2c724aea935151)), closes [#133](https://github.com/strong-roots-capital/od/issues/133)
+
+
+### BREAKING CHANGES
+
+* bump the target for compiled JavaScript from
+ES5 to ES6, which should afford smaller code bundles and faster
+runtimes thanks to newer JavaScript features provided by all
+of the largest, modern browsers.
+
+This is technically a breaking change but is expected to be of no
+impact to most users.
+
 ## [4.0.7](https://github.com/strong-roots-capital/od/compare/v4.0.6...v4.0.7) (2022-01-22)
 
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ const end = D.add('day', 1, start)
 Or just import the functions you need
 
 ``` typescript
-import { add } from 'od/src/lib/add'
+import { add } from 'od/add'
 ```
 
 ## Documentation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "od",
-  "version": "4.0.7",
+  "version": "6.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "od",
-      "version": "4.0.7",
+      "version": "6.0.0",
       "license": "ISC",
       "devDependencies": {
         "@semantic-release/changelog": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "od",
   "version": "4.0.7",
   "description": "Oh dear, another date library",
-  "main": "lib/src/index.js",
-  "types": "lib/src/index.js",
+  "main": "lib/index.js",
+  "types": "lib/index.js",
   "sideEffects": false,
   "scripts": {
     "benchmark": "ts-node perf/add.ts",
@@ -19,7 +19,8 @@
     "prettier": "prettier --write src/**/*.ts spec/**/*.ts test/**/*.ts",
     "prettier:check": "prettier --list-different src/**/*.ts spec/**/*.ts test/**/*.ts",
     "lint-staged": "lint-staged",
-    "semantic-release": "semantic-release"
+    "semantic-release": "semantic-release",
+    "prepublishOnly": "scripts/bundle"
   },
   "repository": {
     "type": "git",
@@ -64,7 +65,10 @@
     "typescript": "4.5.5"
   },
   "files": [
-    "lib/src"
+    "*.js",
+    "*.js.map",
+    "*.d.ts",
+    "*.d.ts.map"
   ],
   "ava": {
     "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "od",
-  "version": "4.0.7",
+  "version": "6.0.0",
   "description": "Oh dear, another date library",
   "main": "lib/index.js",
   "types": "lib/index.js",

--- a/scripts/bundle
+++ b/scripts/bundle
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Bundle the compiled JavaScript in preparation of publication to npm
+#
+# Usage:
+#  bundle
+#
+# (no arguments accepted)
+#
+# Preconditions:
+# - assumes `npm run build` has already been run
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+mv lib/src/* .
+rm -r lib

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "lib": [
       "dom",


### PR DESCRIPTION
This major bump includes two breaking changes:

1. flatten the directory structure of the published
files, which affects the single-function imports.

What used to be imported in v4 as

```typescript
import { add } from 'od/lib/src/add'
```

is now imported as

```typescript
import { add } from 'od/add'
```

While inconvenient, this is hopefully search/replaceable with a tool
like [amber](https://github.com/dalance/amber), and will foster
a simpler developer experience moving forward.

Thank you for your understanding!

2. target es6 compiled JavaScript

