### PR TITLE
fix: point main and types to correct location

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "od",
   "version": "6.0.0",
   "description": "Oh dear, another date library",
-  "main": "lib/index.js",
-  "types": "lib/index.js",
+  "main": "index.js",
+  "types": "index.js",
   "sideEffects": false,
   "scripts": {
     "benchmark": "ts-node perf/add.ts",


### PR DESCRIPTION
This PR will also publish the `beta` dist tag to `latest`, I seem to have introduced
a bug with semantic-release that prevented a new major version from promoting
when beta merged into master.